### PR TITLE
语法、图片归一化以及num_threads问题

### DIFF
--- a/examples/yolov3.cpp
+++ b/examples/yolov3.cpp
@@ -42,19 +42,19 @@ static int detect_yolov3(const cv::Mat& bgr, std::vector<Object>& objects)
     // original pretrained model from https://github.com/eric612/MobileNet-YOLO
     // https://github.com/eric612/MobileNet-YOLO/blob/master/models/yolov3/mobilenet_yolov3_lite_deploy.prototxt
     // https://github.com/eric612/MobileNet-YOLO/blob/master/models/yolov3/mobilenet_yolov3_lite_deploy.caffemodel
-    yolov3.load_param("mobilenet_yolov3.param");
-    yolov3.load_model("mobilenet_yolov3.bin");
+    yolov3.load_param("yolov3-tiny.param");
+    yolov3.load_model("yolov3-tiny.bin");
 
-    const int target_size = 320;
+    const int target_size = 416;
 
     int img_w = bgr.cols;
     int img_h = bgr.rows;
 
-    ncnn::Mat in = ncnn::Mat::from_pixels_resize(bgr.data, ncnn::Mat::PIXEL_BGR, bgr.cols, bgr.rows, target_size, target_size);
+    ncnn::Mat in = ncnn::Mat::from_pixels_resize(bgr.data, ncnn::Mat::PIXEL_RGB2BGR, bgr.cols, bgr.rows, target_size, target_size);
 
-    const float mean_vals[3] = {127.5f, 127.5f, 127.5f};
-    const float norm_vals[3] = {0.007843f, 0.007843f, 0.007843f};
-    in.substract_mean_normalize(mean_vals, norm_vals);
+//    const float mean_vals[3] = {127.5f, 127.5f, 127.5f};
+    const float norm_vals[3] = {1/255.0, 1 / 255.0, 1 / 255.0 };
+    in.substract_mean_normalize(0, norm_vals);
 
     ncnn::Extractor ex = yolov3.create_extractor();
     ex.set_num_threads(4);
@@ -62,7 +62,7 @@ static int detect_yolov3(const cv::Mat& bgr, std::vector<Object>& objects)
     ex.input("data", in);
 
     ncnn::Mat out;
-    ex.extract("detection_out", out);
+    ex.extract("yolo_23", out);
 
 //     printf("%d %d %d\n", out.w, out.h, out.c);
     objects.clear();
@@ -86,12 +86,10 @@ static int detect_yolov3(const cv::Mat& bgr, std::vector<Object>& objects)
 
 static void draw_objects(const cv::Mat& bgr, const std::vector<Object>& objects)
 {
-    static const char* class_names[] = {"background",
-        "aeroplane", "bicycle", "bird", "boat",
-        "bottle", "bus", "car", "cat", "chair",
-        "cow", "diningtable", "dog", "horse",
-        "motorbike", "person", "pottedplant",
-        "sheep", "sofa", "train", "tvmonitor"};
+    static const char* class_names[] = {"background","one",
+        "two", "three", "four", "five",
+        "first", "good"
+	};
 
     cv::Mat image = bgr.clone();
 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -230,7 +230,7 @@ static int get_cpucount()
     return count;
 #else
 #ifdef _OPENMP
-    return omp_get_max_threads();
+	return omp_get_max_threads();
 #else
     return 1;
 #endif // _OPENMP
@@ -241,7 +241,9 @@ static int g_cpucount = get_cpucount();
 
 int get_cpu_count()
 {
-    return g_cpucount;
+	if (g_cpucount == 0)
+		g_cpucount = get_cpucount();
+	return g_cpucount;
 }
 
 #ifdef __ANDROID__

--- a/src/layer/yolov3detection.cpp
+++ b/src/layer/yolov3detection.cpp
@@ -161,14 +161,14 @@ int Yolov3Detection::forward(const std::vector<Mat> &bottom_blobs, std::vector<M
                 float prob = box_score * class_score;
                 if (prob >= confidence_threshold)
                 {
-                    ObjectBox object = {
-                        .xmin = xmin,
-                        .ymin = ymin,
-                        .xmax = xmax,
-                        .ymax = ymax,
-                        .prob = prob,
-                        .classid = class_index,
-                    };
+					ObjectBox object;
+
+					object.xmin = xmin,
+						object.ymin = ymin,
+						object.xmax = xmax,
+						object.ymax = ymax,
+						object.prob = prob,
+						object.classid = class_index,
                     objects.add_new_object_box(object);
                 }
 


### PR DESCRIPTION
1、语法：（VS2017不支持） src\layer\yolov3detection.cpp中的：
if (prob >= confidence_threshold)
{
ObjectBox object = {
.xmin = xmin,
.ymin = ymin,
.xmax = xmax,
.ymax = ymax,
.prob = prob,
.classid = class_index,
};
objects.add_new_object_box(object);
}
改为：
if (prob >= confidence_threshold)
{
ObjectBox object;
object.xmin = xmin,
object.ymin = ymin,
object.xmax = xmax,
object.ymax = ymax,
object.prob = prob,
object.classid = class_index,
objects.add_new_object_box(object);
}
2、图片归一化问题：example\yolov3.cpp中的：
ncnn::Mat in = ncnn::Mat::from_pixels_resize(bgr.data, ncnn::Mat::PIXEL_BGR, bgr.cols, bgr.rows, target_size, target_size);
const float mean_vals[3] = {127.5f, 127.5f, 127.5f};
const float norm_vals[3] = {0.007843f, 0.007843f, 0.007843f};
in.substract_mean_normalize(mean_vals, norm_vals);
改为：
ncnn::Mat in = ncnn::Mat::from_pixels_resize(bgr.data, ncnn::Mat::PIXEL_RGB2BGR, bgr.cols, bgr.rows, target_size, target_size);
const float norm_vals[3] = {1/255.0, 1 / 255.0, 1 / 255.0 };
in.substract_mean_normalize(0, norm_vals);
3、num_threads：src\cpu.cpp中的：
int get_cpu_count()
{
return g_cpucount;
}
改为：
int get_cpu_count()
{
if (g_cpucount == 0)
g_cpucount = get_cpucount();
return g_cpucount;
}yu